### PR TITLE
Added support for finding entry by terminologic code in find_by_code

### DIFF
--- a/lib/iso-639.rb
+++ b/lib/iso-639.rb
@@ -536,7 +536,7 @@ class ISO_639 < Array
     def find_by_code(code)
       case code.length
       when 3
-        ISO_639_2.detect { |entry| entry if entry.alpha3 == code }
+        ISO_639_2.detect { |entry| entry if entry.alpha3 == code || entry.alpha3_terminologic == code }
       when 2
         ISO_639_1.detect { |entry| entry if entry.alpha2 == code }
       end

--- a/test/test_ISO_639.rb
+++ b/test/test_ISO_639.rb
@@ -15,6 +15,10 @@ class TestISO639 < Test::Unit::TestCase
     assert_equal ["eng", "", "en", "English", "anglais"], ISO_639.find_by_code("en")
     assert_equal ["eng", "", "en", "English", "anglais"], ISO_639.find("en")
   end
+
+  should "return entry for alpha-3 terminologic code" do
+    assert_equal ["ger", "deu", "de", "German", "allemand"], ISO_639.find("deu")
+  end
   
   should "find by english name" do
     assert_equal ["eng", "", "en", "English", "anglais"], ISO_639.find_by_english_name("English")


### PR DESCRIPTION
There are scenarios where a terminologic code like `deu` is given and you want to convert this into a bibliographic one like `ger`. Thatswhy it would be nice, if one could do something like

``` ruby
ISO_639.find_by_code("deu")
=> ["ger", "deu", "de", "German", "allemand"]
```
