### PR TITLE
Upgrade mocha and specify minitest dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development, :test do
-  gem "mocha", ">= 0"
+  gem "minitest", "~> 4.7.5"
+  gem "mocha", "~> 0.14.0"
   gem "rdoc", "~> 3.12"
   gem "shoulda", ">= 0"
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,8 @@ GEM
     i18n (0.6.1)
     json (1.7.5)
     metaclass (0.0.1)
-    mocha (0.12.7)
+    minitest (4.7.5)
+    mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.3.6)
     rake (0.9.2.2)
@@ -24,7 +25,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mocha
+  minitest (~> 4.7.5)
+  mocha (~> 0.14.0)
   rake
   rdoc (~> 3.12)
   shoulda

--- a/iso-639.gemspec
+++ b/iso-639.gemspec
@@ -38,16 +38,19 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<mocha>, [">= 0"])
+      s.add_development_dependency(%q<minitest>, ["~> 4.7.5"])
+      s.add_development_dependency(%q<mocha>, ["~> 0.14.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
     else
-      s.add_dependency(%q<mocha>, [">= 0"])
+      s.add_dependency(%q<minitest>, ["~> 4.7.5"])
+      s.add_dependency(%q<mocha>, ["~> 0.14.0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_dependency(%q<shoulda>, [">= 0"])
     end
   else
-    s.add_dependency(%q<mocha>, [">= 0"])
+    s.add_dependency(%q<minitest>, ["~> 4.7.5"])
+    s.add_dependency(%q<mocha>, ["~> 0.14.0"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])
     s.add_dependency(%q<shoulda>, [">= 0"])
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,7 +9,7 @@ rescue Bundler::BundlerError => e
 end
 require 'test/unit'
 require 'shoulda'
-require 'mocha'
+require 'mocha/setup'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
When I checkout the repo and simply run `rake test` I get

``` bash
~/.../mocha-0.12.7/lib/mocha/integration/mini_test.rb:56:in '<class:TestCase>': No Mocha monkey-patch for MiniTest version (RuntimeError)
```

The problem seems to be, that my versions of mocha and minitest do not play together.

Mocha's dependency is very loose at the moment (>= 0) and there is no explicite dependency on minitest at all.

I suggest to add/change the following dependencies

mocha ~> 0.14.0
minitest ~> 4.7.5 (>=5 introduces some breaking changes)

With these changes, I can simply checkout, bundle and run rake without any warnings/errors.
