### PR TITLE
Exception was rised when in ISO_639.find_by_code(code), code was nil

### DIFF
--- a/lib/iso-639.rb
+++ b/lib/iso-639.rb
@@ -534,6 +534,9 @@ class ISO_639 < Array
   class << self
     # Returns the entry array for an alpha-2 or alpha-3 code
     def find_by_code(code)
+      if code.nil? 
+        return 
+      end
       case code.length
       when 3
         ISO_639_2.detect { |entry| entry if entry.alpha3 == code || entry.alpha3_terminologic == code }

--- a/test/test_ISO_639.rb
+++ b/test/test_ISO_639.rb
@@ -11,6 +11,14 @@ class TestISO639 < Test::Unit::TestCase
     assert_equal 184, ISO_639::ISO_639_1.length
   end
   
+  should "return nil find_by_code when code does not exist or is invalid" do
+    assert ISO_639.find_by_code(nil).nil?, 'nil code'
+    assert ISO_639.find_by_code('xxx').nil?, 'xxx alfa-3 not existing code'
+    assert ISO_639.find_by_code('xx').nil?, 'xx alfa-2 not existing code'
+    assert ISO_639.find_by_code('xxxx').nil?, 'xxxx lengthy code'
+    assert ISO_639.find_by_code('').nil? ,'empty string code'
+  end
+  
   should "return entry for alpha-2 code" do
     assert_equal ["eng", "", "en", "English", "anglais"], ISO_639.find_by_code("en")
     assert_equal ["eng", "", "en", "English", "anglais"], ISO_639.find("en")


### PR DESCRIPTION
Whereas in other situations in which the code was invalid the method returned nil, in this case it raised an exception. 

The proposed fix is just check if code is nil in find_by_code. 

Also the pull requests includes  some tests of find_by_code
