### PR TITLE
Add csv gem as a runtime dependency

### DIFF
--- a/iso-639.gemspec
+++ b/iso-639.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |s|
   ]
   s.homepage = 'http://github.com/xwmx/iso-639'
   s.require_paths = ['lib']
+
+  s.add_dependency('csv',                   '~> 3.3')
+
   s.add_development_dependency('minitest',  '~> 5', '>= 0')
   s.add_development_dependency('mocha',     '~> 1', '>= 0')
   s.add_development_dependency('rdoc',      '~> 6', '>= 0')


### PR DESCRIPTION
This PR adds csv gem as a dependency in the gemspec.

Context
As of Ruby 3.3.0 it starts printing a warning when using this gem in a Ruby on Rails app:

../installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/kernel.rb:34: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of iso-639-0.3.6 to add csv into its gemspec.

Since nothing has really changed, I didn't create any spec.